### PR TITLE
feat: Implement ServiceMessage from mad-expo-core

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,9 @@
 import { StatusBar } from "expo-status-bar";
+import { ServiceMessage } from "mad-expo-core";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 
+import { getEnvironment } from "./constants/settings";
 import useCachedResources from "./hooks/useCachedResources";
 import Navigation from "./navigation";
 import store from "./store/config";
@@ -15,6 +17,11 @@ export default function App() {
     return (
       <Provider store={store}>
         <SafeAreaProvider>
+          <ServiceMessage
+            serviceName="HearingTest"
+            environment={getEnvironment()}
+            languageCode="no"
+          />
           <Navigation colorScheme="light" />
           <StatusBar style="dark" />
         </SafeAreaProvider>


### PR DESCRIPTION
- Implements the `ServiceMessage` component from mad-expo-core, enabling the display of service messages from ServicePortal.

Closes #188