### PR TITLE
ci: Add pull request title linter

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,16 @@
+name: Pull Request Linter
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+jobs:
+  lint-pr:
+    name: Lint pull request title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint pull request title
+        uses: jef/conventional-commits-pr-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Action which lints pull request titles for conventional commits.

Closes #246