### PR TITLE
fix: Headset calibration factors

### DIFF
--- a/services/api/api-methods.ts
+++ b/services/api/api-methods.ts
@@ -86,13 +86,13 @@ export const postTakeTest = () =>
   store.getState().appConfig.isDemoMode
     ? postMockTakeTest()
     : postData(`/me/tests/takeTest`, {
-        hz500Db: 0,
-        hz1000Db: 0,
-        hz2000Db: 0,
+        hz500Db: -71.4,
+        hz1000Db: -71.4,
+        hz2000Db: -71.4,
         hz3000Db: -71.4,
         hz4000Db: -65.9,
         hz6000Db: -59.6,
-        hz8000Db: 0,
+        hz8000Db: -71.4,
       });
 
 export const postTest = (body) => postData(`/me/tests`, body);

--- a/services/api/api-methods.ts
+++ b/services/api/api-methods.ts
@@ -86,13 +86,13 @@ export const postTakeTest = () =>
   store.getState().appConfig.isDemoMode
     ? postMockTakeTest()
     : postData(`/me/tests/takeTest`, {
-        hz500Db: -71.4,
-        hz1000Db: -71.4,
+        hz500Db: -74.2,
+        hz1000Db: -74.4,
         hz2000Db: -71.4,
         hz3000Db: -71.4,
         hz4000Db: -65.9,
         hz6000Db: -59.6,
-        hz8000Db: -71.4,
+        hz8000Db: -60.9,
       });
 
 export const postTest = (body) => postData(`/me/tests`, body);


### PR DESCRIPTION
Adjust calibration factors for the frequencies 500 Hz, 1000 Hz, 2000 Hz and 8000 Hz. These frequencies are included in the long test, but not in the short test.

Closes #281