### PR TITLE
refactor: Remove `React.FC`

### DIFF
--- a/components/common/EDS/IconButton.tsx
+++ b/components/common/EDS/IconButton.tsx
@@ -11,13 +11,13 @@ import {
 import { MOSS_GREEN_100, MOSS_GREEN_13 } from "../../../constants/colors";
 import { MaterialIconName } from "../../../types";
 
-type Props = {
+type IconButtonProps = {
   icon: MaterialIconName;
   onPress: (event: GestureResponderEvent) => void;
   style?: StyleProp<ViewStyle>;
 };
 
-export const IconButton: React.FC<Props> = ({ icon, onPress, style }) => {
+export const IconButton = ({ icon, onPress, style }: IconButtonProps) => {
   const [activeTouch, setActiveTouch] = useState(false);
 
   return (

--- a/components/common/atoms/EarLabel.tsx
+++ b/components/common/atoms/EarLabel.tsx
@@ -4,9 +4,9 @@ import { StyleProp, StyleSheet, View, ViewStyle } from "react-native";
 import { LEFT_EAR, RIGHT_EAR } from "../../../constants/colors";
 import { Ear } from "../../../types";
 
-type Props = { ear: Ear; style?: StyleProp<ViewStyle> };
+type EarLabelProps = { ear: Ear; style?: StyleProp<ViewStyle> };
 
-export const EarLabel: React.FC<Props> = ({ ear, style }) => (
+export const EarLabel = ({ ear, style }: EarLabelProps) => (
   <View style={[styles.container, style]}>
     <View
       style={[

--- a/components/common/molecules/Chart.tsx
+++ b/components/common/molecules/Chart.tsx
@@ -21,9 +21,9 @@ import {
 import { CHART, ChartData, HEARING_THRESHOLD } from "../../../types";
 import { getDotSize } from "../../../utils/chart";
 
-type Props = { data: ChartData };
+type ChartProps = { data: ChartData };
 
-export const Chart: React.FC<Props> = ({ data }) => (
+export const Chart = ({ data }: ChartProps) => (
   <VictoryChart
     minDomain={{ x: CHART.HZ_MIN, y: CHART.DB_MIN }}
     maxDomain={{ x: CHART.HZ_MAX, y: CHART.DB_MAX }}

--- a/components/common/molecules/Indicators.tsx
+++ b/components/common/molecules/Indicators.tsx
@@ -2,12 +2,12 @@ import { StyleProp, StyleSheet, View, ViewStyle } from "react-native";
 
 import { MOSS_GREEN_100 } from "../../../constants/colors";
 
-type Props = {
+type IndicatorsProps = {
   iterable: any[];
   style?: StyleProp<ViewStyle>;
 };
 
-export const Indicators: React.FC<Props> = ({ iterable = [], style }) => (
+export const Indicators = ({ iterable = [], style }: IndicatorsProps) => (
   <View style={[styles.container, style]}>
     {iterable.map(({ current, hideIndicator }, index) => {
       if (hideIndicator) {

--- a/components/common/molecules/TestResultItem.tsx
+++ b/components/common/molecules/TestResultItem.tsx
@@ -10,17 +10,17 @@ import { formatDate } from "../../../utils/date";
 import { IconButton } from "../EDS/IconButton";
 import { EarLabel } from "../atoms/EarLabel";
 
-type Props = {
+type TestResultItemProps = {
   data: TestResult;
   resetSelectedItem: () => void;
   hideTop?: boolean;
 };
 
-export const TestResultItem: React.FC<Props> = ({
+export const TestResultItem = ({
   data,
   resetSelectedItem,
   hideTop = false,
-}) => {
+}: TestResultItemProps) => {
   const [chartData, setChartData] = useState<ChartData | null>(null);
 
   useEffect(() => {

--- a/screens/BarCodeScannerScreen.tsx
+++ b/screens/BarCodeScannerScreen.tsx
@@ -8,16 +8,16 @@ import { IconButton } from "../components/common/EDS/IconButton";
 import { RootStackScreenProps } from "../types";
 import { confirmationDialog } from "../utils/alerts";
 
-type Props = RootStackScreenProps<"PreTestRoute"> & {
+type BarCodeScannerScreenProps = RootStackScreenProps<"PreTestRoute"> & {
   onBarcodeMatch: () => void;
   onBarcodeMismatch: () => void;
 };
 
-export const BarCodeScannerScreen: React.FC<Props> = ({
+export const BarCodeScannerScreen = ({
   navigation,
   onBarcodeMatch,
   onBarcodeMismatch,
-}) => {
+}: BarCodeScannerScreenProps) => {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
Remove `React.FC` since it's not the recommended way to type React components.

Closes #287