### PR TITLE
refactor: `Card` component

### DIFF
--- a/components/common/atoms/Card.tsx
+++ b/components/common/atoms/Card.tsx
@@ -1,30 +1,37 @@
-import { TouchableOpacity, View } from "react-native";
+import { ReactNode } from "react";
+import {
+  StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  ViewStyle,
+} from "react-native";
 
-const Card = (props: {
-  children?: any;
-  onPress?: CallableFunction;
-  style?: any;
-}) => {
-  return (
-    <TouchableOpacity onPress={props.onPress} disabled={!props.onPress}>
-      <View
-        style={{
-          backgroundColor: "white",
-          borderRadius: 4,
-          padding: 18,
-          margin: 4,
-          shadowColor: "#000",
-          shadowOffset: { width: 2, height: 2 },
-          shadowOpacity: 0.3,
-          shadowRadius: 3,
-          elevation: 5,
-          ...props.style,
-        }}
-      >
-        {props.children}
-      </View>
-    </TouchableOpacity>
-  );
+type CardProps = {
+  children: ReactNode;
+  onPress?: () => void;
+  style?: StyleProp<ViewStyle>;
 };
 
-export default Card;
+export const Card = ({ children, onPress, style }: CardProps) => (
+  <TouchableOpacity
+    disabled={!onPress}
+    onPress={onPress}
+    style={[styles.container, style]}
+  >
+    {children}
+  </TouchableOpacity>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "white",
+    borderRadius: 4,
+    elevation: 5,
+    margin: 4,
+    padding: 18,
+    shadowColor: "#000",
+    shadowOffset: { width: 2, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+  },
+});

--- a/components/common/atoms/NavigationItem.tsx
+++ b/components/common/atoms/NavigationItem.tsx
@@ -1,14 +1,11 @@
 import { MaterialIcons as Icon } from "@expo/vector-icons";
 import { View } from "react-native";
 
-import Card from "./Card";
+import { Card } from "./Card";
 import Typography from "./Typography";
 import { EQUINOR_GREEN } from "../../../constants/colors";
 
-const NavigationItem = (props: {
-  title: string;
-  onPress?: CallableFunction;
-}) => {
+const NavigationItem = (props: { title: string; onPress?: () => void }) => {
   return (
     <Card onPress={props.onPress} style={{ height: 80 }}>
       <View

--- a/components/common/molecules/TestCard.tsx
+++ b/components/common/molecules/TestCard.tsx
@@ -6,7 +6,7 @@ import { postTest } from "../../../store/test/actions";
 import { selectIsFetching } from "../../../store/test/reducer";
 import { getUnsentTests } from "../../../store/unsent-tests/reducer";
 import { RootStackParamList } from "../../../types";
-import Card from "../atoms/Card";
+import { Card } from "../atoms/Card";
 import Typography from "../atoms/Typography";
 
 type Cards = {


### PR DESCRIPTION
- Add `CardProps` type and correct the prop types.
- Switch from default to named export.
- Remove unnecessary `View` component.
- Move styles to stylesheet.

Closes #300