### PR TITLE
refactor: Use `alert` from `@equinor/mad-components`

### DIFF
--- a/screens/SoundCheckScreen.tsx
+++ b/screens/SoundCheckScreen.tsx
@@ -1,14 +1,7 @@
 import { Button } from "@equinor/mad-components";
 import { MaterialIcons as Icon } from "@expo/vector-icons";
 import { useEffect, useRef, useState } from "react";
-import {
-  Alert,
-  Animated,
-  Modal,
-  ScrollView,
-  StyleSheet,
-  View,
-} from "react-native";
+import { Animated, Modal, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Sound from "react-native-sound";
 import SystemSetting from "react-native-system-setting";
@@ -234,9 +227,6 @@ const SoundCheckScreen = ({ navigation }: SoundCheckScreenProps) => {
               animationType="slide"
               transparent={false}
               visible={modalVisible}
-              onRequestClose={() => {
-                Alert.alert("Modal has been closed.");
-              }}
             >
               <SafeAreaView
                 style={{

--- a/utils/alerts.ts
+++ b/utils/alerts.ts
@@ -1,11 +1,11 @@
-import { Alert } from "react-native";
+import { alert } from "@equinor/mad-components";
 
 export const confirmationDialog = (
   title: string,
-  onConfirm: (value?: string) => void,
-  message?: string
+  onConfirm: () => void,
+  message = ""
 ) =>
-  Alert.alert(title, message, [
+  alert(title, message, [
     {
       text: "Nei",
       onPress: () => {},

--- a/utils/linking.ts
+++ b/utils/linking.ts
@@ -1,4 +1,5 @@
-import { Alert, Linking } from "react-native";
+import { alert } from "@equinor/mad-components";
+import { Linking } from "react-native";
 
 import { URL } from "../types";
 
@@ -7,6 +8,8 @@ export const openURL = async (url: URL) => {
   if (canOpenURL) {
     await Linking.openURL(url);
   } else {
-    Alert.alert(`Don't know how to open this URL: ${url}`);
+    alert("Ups!", `Klarte ikke å åpne siden: ${url}`, [
+      { text: "OK", onPress: () => {}, style: "cancel" },
+    ]);
   }
 };


### PR DESCRIPTION
- Replace `Alert.alert` from `react-native` with `alert` from `@equinor/mad-components`.
- Remove unused code.

Closes #302