### PR TITLE
refactor: Replace back button icon

### DIFF
--- a/components/common/molecules/TestResultsModal.tsx
+++ b/components/common/molecules/TestResultsModal.tsx
@@ -43,10 +43,11 @@ const TestResultsModal = (props: {
         }}
       >
         <Button.Icon
-          name="format-list-bulleted"
+          name="chevron-left"
           onPress={() => setSelectedItem(null)}
           variant="ghost"
           disabled={!selectedItem}
+          style={{ opacity: selectedItem ? 1 : 0 }}
         />
         <Typography variant="h3" color="primary">
           Dine resultater


### PR DESCRIPTION
- Replace the icon to go back to the list of test results when viewing a test result chart.
- Hide the back button when viewing the list of test results.

Closes #313