### PR TITLE
refactor: `TestResultScreen`

### DIFF
--- a/hooks/useTestResultPages.ts
+++ b/hooks/useTestResultPages.ts
@@ -1,29 +1,42 @@
+import { ButtonProps } from "@equinor/mad-components";
+import { ImageSourcePropType } from "react-native";
+
 import doctor from "../assets/images/doctor.png";
 import thumbsUp from "../assets/images/thumbs-up.png";
 import warning from "../assets/images/warning.png";
-import {
-  TestResultButtonConfigurations,
-  TestResultPage,
-  TestResult,
-} from "../types";
+import { ANALYSIS_FLAG, TestResult } from "../types";
+
+type TestResultPage = {
+  title: string;
+  image: ImageSourcePropType;
+  subtitle: string;
+  description: string;
+  buttons: ButtonProps[];
+};
+
+type TestResultPages = {
+  newTestInSixMonths: TestResultPage;
+  newTestRecommended: TestResultPage;
+  hearingChangeDetected: TestResultPage;
+  sendingTestFailed: TestResultPage;
+  testIsSent: TestResultPage;
+};
+
+export type TestResultPageButtons = {
+  seeResult: ButtonProps;
+  newTest: ButtonProps;
+  sendTest: ButtonProps;
+};
 
 export const useTestResultPages = (
   testResult: TestResult,
-  buttons: TestResultButtonConfigurations
+  buttons: TestResultPageButtons
 ) => {
-  type Pages = {
-    newTestInSixMonths: TestResultPage;
-    newTestRecommended: TestResultPage;
-    hearingChangeDetected: TestResultPage;
-    testIsSent: TestResultPage;
-    sendingTestFailed: TestResultPage;
-  };
-
-  const pages: Pages = {
+  const pages: TestResultPages = {
     newTestInSixMonths: {
       title: "Testen er fullført",
       image: thumbsUp,
-      subTitle: "Dette ser fint ut!",
+      subtitle: "Dette ser fint ut!",
       description:
         "Du vil få en ny invitasjon om 6 måneder, men vær oppmerksom på at jo oftere du tar testen, jo bedre.",
       buttons: [buttons.seeResult],
@@ -31,7 +44,7 @@ export const useTestResultPages = (
     newTestRecommended: {
       title: "Her ble det litt krøll",
       image: warning,
-      subTitle: "Takk for at du gjennomførte testen",
+      subtitle: "Takk for at du gjennomførte testen",
       description:
         "For beste mulige resultater, vennligst ta hørselstesten på ny.",
       buttons: [buttons.newTest],
@@ -39,7 +52,7 @@ export const useTestResultPages = (
     hearingChangeDetected: {
       title: "Testen er fullført",
       image: doctor,
-      subTitle: "Takk for at du gjennomførte testen",
+      subtitle: "Takk for at du gjennomførte testen",
       description:
         "Det er oppdaget en endring i hørselen din. Vennligst ta kontakt med sykepleier for en manuell undersøkelse.",
       buttons: [buttons.seeResult],
@@ -47,7 +60,7 @@ export const useTestResultPages = (
     sendingTestFailed: {
       title: "Her ble det litt krøll",
       image: warning,
-      subTitle: "Testen ble ikke sendt",
+      subtitle: "Testen ble ikke sendt",
       description:
         "Testen ble lagret, men den må sendes for undersøkelse. Koble deg på nettet og prøv igjen. Testen kan også sendes fra hovedmenyen.",
       buttons: [buttons.sendTest],
@@ -55,7 +68,7 @@ export const useTestResultPages = (
     testIsSent: {
       title: "Testen er fullført",
       image: thumbsUp,
-      subTitle: "Takk for at du testet appen!",
+      subtitle: "Takk for at du testet appen!",
       description:
         "Du blir kontaktet av en lege dersom du har problemer med hørselen.",
       buttons: [buttons.seeResult],
@@ -63,13 +76,13 @@ export const useTestResultPages = (
   };
 
   switch (testResult.result) {
-    case "Ok":
+    case ANALYSIS_FLAG.OK:
       return pages.newTestInSixMonths;
-    case "Outlier":
+    case ANALYSIS_FLAG.OUTLIER:
       return pages.newTestRecommended;
-    case "NotOk":
+    case ANALYSIS_FLAG.NOT_OK:
       return pages.hearingChangeDetected;
-    case "SendFailed":
+    case ANALYSIS_FLAG.SEND_FAILED:
       return pages.sendingTestFailed;
     default:
       return pages.testIsSent;

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -39,7 +39,7 @@ import NotFoundScreen from "../screens/NotFoundScreen";
 import { PreTestScreen } from "../screens/PreTestScreen";
 import SoundCheckFinishedScreen from "../screens/SoundCheckFinishedScreen";
 import SoundCheckScreen from "../screens/SoundCheckScreen";
-import TestResultScreen from "../screens/TestResultScreen";
+import { TestResultScreen } from "../screens/TestResultScreen";
 import TestScreen from "../screens/TestScreen";
 import { setConfig } from "../store/app-config/actions";
 import store from "../store/config";

--- a/store/test/reducer.ts
+++ b/store/test/reducer.ts
@@ -14,7 +14,7 @@ import {
   success,
 } from "./actions";
 import * as mockData from "../../services/api/mocked-api-methods/mock-data.json";
-import { Error, stateKeys } from "../../types";
+import { Error, stateKeys, TestResult } from "../../types";
 
 function setNextNode(state, userResponse) {
   const clonedState = _.cloneDeep(state);
@@ -167,7 +167,7 @@ export const selectTestIsFinished = (state): boolean =>
 export const selectTestIsRunning = (state): boolean =>
   state[stateKeys.TEST].testIsRunning;
 export const selectResults = (state) => state[stateKeys.TEST].results;
-export const selectTestResult = (state) =>
+export const selectTestResult = (state): TestResult =>
   state.appConfig.isDemoMode
     ? mockData.Tests[0]
     : state[stateKeys.TEST].testResult;

--- a/types.tsx
+++ b/types.tsx
@@ -3,10 +3,8 @@
  * https://reactnavigation.org/docs/typescript/
  */
 
-import { ButtonProps } from "@equinor/mad-components";
 import { MaterialIcons } from "@expo/vector-icons";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { ImageSourcePropType } from "react-native";
 
 declare global {
   namespace ReactNavigation {
@@ -63,7 +61,7 @@ export type HearingLevel = {
   db: number;
 };
 
-const ANALYSIS_FLAG = {
+export const ANALYSIS_FLAG = {
   UNDEFINED: "Undefined",
   OK: "Ok",
   OUTLIER: "Outlier",
@@ -133,18 +131,4 @@ export type Sound = {
   hz: number;
   uri: string;
   lastModified: Date;
-};
-
-export type TestResultButtonConfigurations = {
-  seeResult: ButtonProps;
-  newTest: ButtonProps;
-  sendTest: ButtonProps;
-};
-
-export type TestResultPage = {
-  title: string;
-  image: ImageSourcePropType;
-  subTitle: string;
-  description: string;
-  buttons: ButtonProps[];
 };


### PR DESCRIPTION
### useTestResultPages

- Move types to where they belong.
- Rename `subTitle` to `subtitle`.
- Use `ANALYSIS_FLAG` constants instead of hard coded values.
- Rename type `TestResultButtonConfigurations` to `TestResultPageButton`.
- Rename type `Pages` to `TestResultPages`.
- Move type `TestResultPages` out of component function.

### TestResultScreen

- Export `TestResultScreen` as named export instead of default export.
- Use `useDispatch` and `useSelector` hooks from `react-redux` instead of `connect`.
- Move styles into stylesheet.
- Set button width to 160, same size as on other screens.
- Make all content visible when `ErrorBanner` is dsiplayed by adding `ScrollView` to the other content.

Closes #321