### PR TITLE
refactor: Use `MaterialCommunityIcons`

### DIFF
--- a/components/common/atoms/MenuItem.tsx
+++ b/components/common/atoms/MenuItem.tsx
@@ -1,12 +1,12 @@
 import { Typography } from "@equinor/mad-components";
-import { MaterialIcons as Icon } from "@expo/vector-icons";
+import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
 import { StyleSheet, TouchableOpacity } from "react-native";
 
 import { ICON } from "../../../constants/colors";
-import { MaterialIconName } from "../../../types";
+import { MaterialCommunityIconName } from "../../../types";
 
 type Props = {
-  icon: MaterialIconName;
+  icon: MaterialCommunityIconName;
   text: string;
   onPress: () => void;
 };

--- a/components/common/atoms/NavigationItem.tsx
+++ b/components/common/atoms/NavigationItem.tsx
@@ -1,5 +1,5 @@
 import { Typography } from "@equinor/mad-components";
-import { MaterialIcons as Icon } from "@expo/vector-icons";
+import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
 import { StyleSheet } from "react-native";
 
 import { Card } from "./Card";

--- a/hooks/useCachedResources.ts
+++ b/hooks/useCachedResources.ts
@@ -1,4 +1,4 @@
-import { MaterialIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 import * as Font from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { appInsightsInit, msalInit } from "mad-expo-core";
@@ -21,7 +21,7 @@ export default function useCachedResources() {
 
         // Load fonts
         await Font.loadAsync({
-          ...MaterialIcons.font,
+          ...MaterialCommunityIcons.font,
         });
 
         await msalInit(AzureADClientId, AzureADRedirectUrl);

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Typography } from "@equinor/mad-components";
-import { MaterialIcons as Icon } from "@expo/vector-icons";
+import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
 import {
   DarkTheme,
   DefaultTheme,
@@ -138,7 +138,7 @@ function RootNavigator() {
               onPress={() => navigation.navigate("SettingsRoute")}
               style={{ paddingHorizontal: 15 }}
             >
-              <Icon name="more-vert" color={EQUINOR_GREEN} size={24} />
+              <Icon name="dots-vertical" color={EQUINOR_GREEN} size={24} />
             </TouchableOpacity>
           ),
           headerShadowVisible: false,

--- a/screens/SoundCheckScreen.tsx
+++ b/screens/SoundCheckScreen.tsx
@@ -1,5 +1,5 @@
 import { Button, Typography } from "@equinor/mad-components";
-import { MaterialIcons as Icon } from "@expo/vector-icons";
+import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
 import { useEffect, useRef, useState } from "react";
 import { Animated, Modal, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";

--- a/types.tsx
+++ b/types.tsx
@@ -4,7 +4,7 @@
  */
 
 import { ButtonProps } from "@equinor/mad-components";
-import { MaterialIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { ImageSourcePropType } from "react-native";
 
@@ -113,7 +113,8 @@ export type SoundCheckPageJSON = {
   };
 };
 
-export type MaterialIconName = keyof typeof MaterialIcons.glyphMap;
+export type MaterialCommunityIconName =
+  keyof typeof MaterialCommunityIcons.glyphMap;
 
 export type Error = { message: string | null; status: number | null };
 


### PR DESCRIPTION
- Switch from `MaterialIcons` to `MaterialCommunityIcons` which is the same as `@equinor/mad-components` uses.

Closes #269