### PR TITLE
feat: Ignore `preDelayMs` if previous node was not heard

### DIFF
--- a/hooks/useHearingTest.ts
+++ b/hooks/useHearingTest.ts
@@ -41,6 +41,7 @@ export const useHearingTest = () => {
   const reactionTimeMsRef = useRef<number | null>(null);
   const isPlayingFirstNodeFirstTimeRef = useRef(true);
   const numberOfPressesRef = useRef(0);
+  const prevSuccessRef = useRef(true);
   const successRef = useRef(false);
 
   const { progress, setNumberOfNodesPlayed } = useHearingTestProgress();
@@ -83,7 +84,7 @@ export const useHearingTest = () => {
     timerMsRef.current = 0;
     reactionTimeMsRef.current = null;
     successRef.current = false;
-    preDelayMsRef.current = node.data.preDelayMs;
+    preDelayMsRef.current = prevSuccessRef.current ? node.data.preDelayMs : 0;
 
     let soundHasBeenPlayed = false;
     const intervalSpeedMs = 1;
@@ -141,6 +142,8 @@ export const useHearingTest = () => {
     if (isPlayingFirstNodeFirstTimeRef.current) {
       isPlayingFirstNodeFirstTimeRef.current = false;
     }
+
+    prevSuccessRef.current = successRef.current;
 
     if (successRef.current) {
       dispatch(actionSuccess(payload));


### PR DESCRIPTION
Currently, each node in the hearing test includes a preDelayMs value that specifies the amount of time to wait before playing the node's sound after the previous node has finished. However, if the patient did not hear the previous sound, there is no need to wait the full preDelayMs before playing the next sound.

This update will improve the efficiency of the hearing test by ignoring the preDelayMs value when the previous node was not heard, resulting in a shorter overall test time.

Closes #343