### PR TITLE
refactor: Migrate from `expo-barcode-scanner` to `expo-camera`

### DIFF
--- a/app.json
+++ b/app.json
@@ -46,7 +46,12 @@
         }
       ],
       "expo-localization",
-      "expo-font"
+      "expo-font",
+      ["expo-camera",
+        {
+          "cameraPermission": "Tillat $(PRODUCT_NAME) å bruke kameraet ditt."
+        }
+      ]
     ],
     "web": {
       "favicon": "./assets/images/favicon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/native-stack": "^6.9.1",
         "@redux-devtools/extension": "^3.2.3",
         "expo": "^50.0.3",
-        "expo-barcode-scanner": "~12.9.2",
+        "expo-camera": "~14.0.3",
         "expo-crypto": "~12.8.0",
         "expo-dev-client": "~3.3.7",
         "expo-font": "~11.10.2",
@@ -11283,12 +11283,12 @@
         "md5-file": "^3.2.3"
       }
     },
-    "node_modules/expo-barcode-scanner": {
-      "version": "12.9.2",
-      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-12.9.2.tgz",
-      "integrity": "sha512-szsGCWMu6HXWigSKvGy7q+5v7EyIUr4SYdmMhzLxNQmNA8fPP2t2SMOhX8AVcGAqu9nOY7ij0bZUtAWrLFo6FA==",
+    "node_modules/expo-camera": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-14.0.3.tgz",
+      "integrity": "sha512-AKeV6wHfAf2U8b/9IzevXY/F86ydHZkA+pf/G7fzBRh8F//ACDmSuqG63aRQbm5o+CA4AxG4xD+iUDTwrl//rg==",
       "dependencies": {
-        "expo-image-loader": "~4.6.0"
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "expo": "*"
@@ -11485,14 +11485,6 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-image-loader": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.6.0.tgz",
-      "integrity": "sha512-RHQTDak7/KyhWUxikn2yNzXL7i2cs16cMp6gEAgkHOjVhoCJQoOJ0Ljrt4cKQ3IowxgCuOrAgSUzGkqs7omj8Q==",
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-navigation/native-stack": "^6.9.1",
     "@redux-devtools/extension": "^3.2.3",
     "expo": "^50.0.3",
-    "expo-barcode-scanner": "~12.9.2",
+    "expo-camera": "~14.0.3",
     "expo-crypto": "~12.8.0",
     "expo-dev-client": "~3.3.7",
     "expo-font": "~11.10.2",

--- a/screens/BarcodeScannerScreen.tsx
+++ b/screens/BarcodeScannerScreen.tsx
@@ -1,6 +1,6 @@
 import { Button, Typography } from "@equinor/mad-components";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { BarCodeScanner } from "expo-barcode-scanner";
+import { BarcodeScanningResult, Camera, CameraView } from "expo-camera/next";
 import { useEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -8,31 +8,31 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { RootStackParamList } from "../types";
 import { confirmationDialog } from "../utils/alerts";
 
-type BarCodeScannerScreenProps = {
+type BarcodeScannerScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, "PreTestRoute">;
   onBarcodeMatch: () => void;
   onBarcodeMismatch: () => void;
 };
 
-export const BarCodeScannerScreen = ({
+export const BarcodeScannerScreen = ({
   navigation,
   onBarcodeMatch,
   onBarcodeMismatch,
-}: BarCodeScannerScreenProps) => {
+}: BarcodeScannerScreenProps) => {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
   const insets = useSafeAreaInsets();
 
   useEffect(() => {
-    const getBarCodeScannerPermissions = async () => {
-      const { status } = await BarCodeScanner.requestPermissionsAsync();
+    const getCameraPermissions = async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
       setHasPermission(status === "granted");
     };
 
-    getBarCodeScannerPermissions();
+    getCameraPermissions();
   }, []);
 
-  const handleBarCodeScanned = ({ data }) => {
+  const handleBarcodeScanned = ({ data }: BarcodeScanningResult) => {
     setScanned(true);
     if (data === "01122022") {
       onBarcodeMatch();
@@ -64,8 +64,11 @@ export const BarCodeScannerScreen = ({
         />
       </View>
       {hasPermission ? (
-        <BarCodeScanner
-          onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+        <CameraView
+          onBarcodeScanned={scanned ? undefined : handleBarcodeScanned}
+          barcodeScannerSettings={{
+            barCodeTypes: ["ean8"],
+          }}
           style={StyleSheet.absoluteFillObject}
         />
       ) : (

--- a/screens/PreTestScreen/PreTestScreen.tsx
+++ b/screens/PreTestScreen/PreTestScreen.tsx
@@ -7,7 +7,7 @@ import { ButtonGroup } from "../../components/common/atoms/ButtonGroup";
 import { Indicators } from "../../components/common/molecules/Indicators";
 import { RootStackScreenProps } from "../../types";
 import { confirmationDialog } from "../../utils/alerts";
-import { BarCodeScannerScreen } from "../BarCodeScannerScreen";
+import { BarcodeScannerScreen } from "../BarcodeScannerScreen";
 
 type PreTestScreenProps = RootStackScreenProps<"PreTestRoute">;
 
@@ -16,7 +16,7 @@ export const PreTestScreen = ({ navigation }: PreTestScreenProps) => {
 
   if (page.title === "Skann") {
     return (
-      <BarCodeScannerScreen
+      <BarcodeScannerScreen
         navigation={navigation}
         onBarcodeMatch={() => nextPage(2)}
         onBarcodeMismatch={() => nextPage()}


### PR DESCRIPTION
Migrate from the deprecated `expo-barcode-scanner` to `expo-camera`.

Closes #346