### PR TITLE
fix: Display dialog when pressing no on subdialog

### DIFF
--- a/hooks/useHearingTest.ts
+++ b/hooks/useHearingTest.ts
@@ -186,13 +186,6 @@ export const useHearingTest = () => {
     navigation.navigate("TestRoute");
   };
 
-  console.log({
-    isFetching,
-    isSoundFilesLoaded,
-    pauseAfterNode,
-    dialog,
-  });
-
   const isLoading =
     isFetching ||
     !isSoundFilesLoaded ||

--- a/hooks/useHearingTest.ts
+++ b/hooks/useHearingTest.ts
@@ -35,6 +35,7 @@ type Dialog = ObjectValues<typeof DIALOG>;
 export const useHearingTest = () => {
   const [pauseAfterNode, setPauseAfterNode] = useState(false);
   const [dialog, setDialog] = useState<Dialog>(DIALOG.HIDDEN);
+  const isDialogOpen = dialog === DIALOG.OPEN || dialog === DIALOG.SUBDIALOG;
 
   const isFetching = useSelector(selectIsFetching);
   const testIsRunning = useSelector(selectTestIsRunning);
@@ -67,28 +68,19 @@ export const useHearingTest = () => {
   }, [isConnected, isFetching, test]);
 
   useEffect(() => {
-    if (
-      pauseAfterNode &&
-      dialog === DIALOG.HIDDEN &&
-      previousNodeRef.current !== node
-    ) {
+    if (pauseAfterNode && !isDialogOpen && previousNodeRef.current !== node) {
       setPauseAfterNode(false);
       setDialog(DIALOG.OPEN);
     }
-  }, [pauseAfterNode, dialog, node]);
+  }, [pauseAfterNode, isDialogOpen, node]);
 
   useEffect(() => {
-    if (
-      !testIsRunning ||
-      pauseAfterNode ||
-      dialog === DIALOG.OPEN ||
-      dialog === DIALOG.SUBDIALOG
-    ) {
+    if (!testIsRunning || pauseAfterNode || isDialogOpen) {
       return;
     }
 
     runNode();
-  }, [testIsRunning, pauseAfterNode, dialog, node]);
+  }, [testIsRunning, pauseAfterNode, isDialogOpen, node]);
 
   const runNode = () => {
     if (previousNodeRef.current?.data.index !== 1 && node.data.index === 1) {
@@ -187,17 +179,13 @@ export const useHearingTest = () => {
   };
 
   const isLoading =
-    isFetching ||
-    !isSoundFilesLoaded ||
-    pauseAfterNode ||
-    dialog === DIALOG.OPEN ||
-    dialog === DIALOG.SUBDIALOG;
+    isFetching || !isSoundFilesLoaded || pauseAfterNode || isDialogOpen;
 
   const showOfflineCard =
     isConnected === false && Object.keys(test).length === 0;
 
   return {
-    dialog,
+    isDialogOpen,
     isLoading,
     pauseAfterNode,
     progress,

--- a/screens/TestScreen/TestScreenComponent.tsx
+++ b/screens/TestScreen/TestScreenComponent.tsx
@@ -9,18 +9,18 @@ import { MuteButton } from "../../components/common/atoms/MuteButton";
 import { Loading } from "../../components/common/molecules/Loading";
 import { TestCard } from "../../components/common/molecules/TestCard";
 import { useHearingNavigation } from "../../hooks/useHearingNavigation";
-import { useHearingTest } from "../../hooks/useHearingTest";
+import { DIALOG, useHearingTest } from "../../hooks/useHearingTest";
 import { confirmationDialog } from "../../utils/alerts";
 
 export const TestScreenComponent = () => {
   const {
-    isDialogOpen,
+    dialog,
     isLoading,
     pauseAfterNode,
     progress,
     registerPress,
     restartTest,
-    setIsDialogOpen,
+    setDialog,
     setPauseAfterNode,
     showOfflineCard,
     startTest,
@@ -95,12 +95,13 @@ export const TestScreenComponent = () => {
           <BottomButton />
         </View>
       </SafeAreaView>
-      <Dialog isOpen={isDialogOpen}>
+      <Dialog isOpen={dialog === DIALOG.OPEN || dialog === DIALOG.SUBDIALOG}>
         <Dialog.CustomContent>
           <MenuItem
             icon="close"
             text="Avslutte testen"
-            onPress={() =>
+            onPress={() => {
+              setDialog(DIALOG.SUBDIALOG);
               confirmationDialog(
                 "Avslutte hørselstesten?",
                 () => {
@@ -108,26 +109,28 @@ export const TestScreenComponent = () => {
                   navigation.navigate("Root");
                 },
                 "Da må du begynne på nytt neste gang",
-                () => setIsDialogOpen(true)
-              )
-            }
+                () => setDialog(DIALOG.OPEN)
+              );
+            }}
           />
           <MenuItem
             icon="replay"
             text="Start hørselstesten på ny"
-            onPress={() =>
+            onPress={() => {
+              setDialog(DIALOG.SUBDIALOG);
               confirmationDialog(
                 "Starte hørselstesten på ny?",
                 restartTest,
                 "Dette vil slette all data fra denne testen",
-                () => setIsDialogOpen(true)
-              )
-            }
+                () => setDialog(DIALOG.OPEN)
+              );
+            }}
           />
           <MenuItem
             icon="headphones"
             text="Ta ny lydsjekk"
-            onPress={() =>
+            onPress={() => {
+              setDialog(DIALOG.SUBDIALOG);
               confirmationDialog(
                 "Ta ny lydsjekk?",
                 () => {
@@ -135,13 +138,13 @@ export const TestScreenComponent = () => {
                   navigation.navigate("SoundCheckRoute");
                 },
                 "Dette vil slette all data fra denne testen",
-                () => setIsDialogOpen(true)
-              )
-            }
+                () => setDialog(DIALOG.OPEN)
+              );
+            }}
           />
           <Button
             title="Fortsette hørselstesten"
-            onPress={() => setIsDialogOpen(false)}
+            onPress={() => setDialog(DIALOG.HIDDEN)}
             style={styles.continueHearingTestButton}
           />
         </Dialog.CustomContent>

--- a/screens/TestScreen/TestScreenComponent.tsx
+++ b/screens/TestScreen/TestScreenComponent.tsx
@@ -14,7 +14,7 @@ import { confirmationDialog } from "../../utils/alerts";
 
 export const TestScreenComponent = () => {
   const {
-    dialog,
+    isDialogOpen,
     isLoading,
     pauseAfterNode,
     progress,
@@ -95,7 +95,7 @@ export const TestScreenComponent = () => {
           <BottomButton />
         </View>
       </SafeAreaView>
-      <Dialog isOpen={dialog === DIALOG.OPEN || dialog === DIALOG.SUBDIALOG}>
+      <Dialog isOpen={isDialogOpen}>
         <Dialog.CustomContent>
           <MenuItem
             icon="close"

--- a/types.tsx
+++ b/types.tsx
@@ -68,7 +68,7 @@ export const ANALYSIS_FLAG = {
   SEND_FAILED: "SendFailed",
 } as const;
 
-type ObjectValues<T> = T[keyof T];
+export type ObjectValues<T> = T[keyof T];
 
 export type AnalysisFlag = ObjectValues<typeof ANALYSIS_FLAG>;
 


### PR DESCRIPTION
Previously when pressing no on a subdialog of the pause modal during a hearing test the screen would be stuck displaying a spinner. This commit fixes that issue.

Closes #356