### PR TITLE
fix: Remove slash from API base URL

### DIFF
--- a/constants/env-configs/test.json
+++ b/constants/env-configs/test.json
@@ -3,7 +3,7 @@
   "Resources": {
     "hearing": {
       "AzureADResourceId": "51cb4e59-b091-4223-8f5b-54c6e785dd4e",
-      "ApiBaseUrl": "https://api-hearing-api-test.radix.equinor.com/api/v2.0/",
+      "ApiBaseUrl": "https://api-hearing-api-test.radix.equinor.com/api/v2.0",
       "scopes": [
         "api://51cb4e59-b091-4223-8f5b-54c6e785dd4e/user_impersonation"
       ]

--- a/constants/settings.json
+++ b/constants/settings.json
@@ -3,7 +3,7 @@
   "Resources": {
     "hearing": {
       "AzureADResourceId": "51cb4e59-b091-4223-8f5b-54c6e785dd4e",
-      "ApiBaseUrl": "https://api-hearing-api-test.radix.equinor.com/api/v2.0/",
+      "ApiBaseUrl": "https://api-hearing-api-test.radix.equinor.com/api/v2.0",
       "scopes": [
         "api://51cb4e59-b091-4223-8f5b-54c6e785dd4e/user_impersonation"
       ]


### PR DESCRIPTION
The previous base url had an extra slash causing requests to fail. This commit removes the extra slash to allow requests to go through properly.

Closes #396