### PR TITLE
fix: add app version to telemetry

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,13 +6,15 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 
 import useCachedResources from "./hooks/useCachedResources";
+import { useTelemetryInitializer } from "./hooks/useTelemetryInitializer";
 import Navigation from "./navigation";
 import store from "./store/config";
 
 export default function App() {
   const isLoadingComplete = useCachedResources();
+  const { isTelemetryInitialized } = useTelemetryInitializer();
 
-  if (!isLoadingComplete) {
+  if (!isLoadingComplete || !isTelemetryInitialized) {
     return null;
   } else {
     return (

--- a/hooks/useTelemetryInitializer.ts
+++ b/hooks/useTelemetryInitializer.ts
@@ -1,0 +1,20 @@
+import { addTelemetryInitializer, Envelope } from "@equinor/mad-core";
+import { useEffect, useState } from "react";
+
+import AppInfo from "../app.json";
+
+export const useTelemetryInitializer = () => {
+  const [isTelemetryInitialized, setIsTelemetryInitialized] = useState(false);
+
+  useEffect(() => {
+    const appVersionEnvelope: Envelope = (item) => {
+      if (item.data) {
+        item.data["app-version"] = AppInfo.expo.version;
+      }
+    };
+    addTelemetryInitializer(appVersionEnvelope);
+    setIsTelemetryInitialized(true);
+  }, []);
+
+  return { isTelemetryInitialized };
+};


### PR DESCRIPTION
Adds `app-version` as a custom property to all events logged to Application Insights.

Closes #426